### PR TITLE
[DEV-572] use environment variable for node image in build config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ jobs:
       - run:
           name: Set NPMJS Registry
           command: npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-      - run: npm install
+      - run:
+          name: Clean install NPM packages
+          command: npm ci
       - run:
           name: Semantic Release
           # Must include on the npx command any packages for any plugins specified in .releaserc that are not part of the main semantic-release package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ jobs:
           name: Semantic Release
           # Must include on the npx command any packages for any plugins specified in .releaserc that are not part of the main semantic-release package
           # See: https://github.com/semantic-release/semantic-release/blob/master/docs/extending/plugins-list.md
-          command: npx -p @semantic-release/changelog -p @semantic-release/git -p semantic-release semantic-release
+          # semantic release packages are pinned the highest version we know works in our environment
+          command: npx -p @semantic-release/changelog@5.0.0 -p @semantic-release/git@9.0.0 -p semantic-release@17.0.1 semantic-release
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,9 @@ version: 2
 
 defaults: &defaults
   shell: /bin/bash --login
+  # Docker image ENV variables are set in the CircleCI config per project.
   docker:
-    - image: circleci/node:10.16.0-stretch
+    - image: ${DOCKER_NODE_IMAGE}
 
 jobs:
         


### PR DESCRIPTION
Update to CircleCI config file to accommodate updates to semantic release

- use env variables for node image
- pin semantic release package versions
- changed CircleCI to run npm ci