### PR TITLE
Set `trailingComma: "none"` to override Prettier v2 default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
-  singleQuote: true,
   arrowParens: "always",
+  printWidth: 120,
+  singleQuote: true,
   tabWidth: 4,
-  printWidth: 120
+  trailingComma: "none"
 };


### PR DESCRIPTION
Prettier 2.x has changed the [default value](https://prettier.io/blog/2020/03/21/2.0.0.html) of `trailingComma` to `es5`. This has the effect of adding a comma after the last element in a list. Example:

```
const list = [ 
    'one', 
    'two', 
    'three',  <-- here I am!
];
``` 

Unless there are objections, @dhjonesclc and I just figured we'd retain the existing format rule of `"none"` so the trailing comma is not included.