### PR TITLE
[DEV-1569] Add import order autoformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Shareable prettier configuration.
 
 ## Builds and Deployment
+
 ![master](https://img.shields.io/circleci/build/github/CLCInc/prettier-config-clc/master?label=master&style=flat-square&token=0963d0715ce24f1c526725250f9ae7ed1b42e88b)
 ![Semantic Release](https://img.shields.io/badge/deploy-semantic%20release-blueviolet?style=flat-square&link=https://github.com/CLCInc/documentation/wiki/Git-Commit-Guidelines)
 
@@ -12,7 +13,8 @@ To add this file to your own project, add the following to your project's `packa
   "prettier": "@clc_inc/prettier-config-clc"
   "devDependencies": {
     "prettier": "^1.19.1",
-    "@clc_inc/prettier-config-clc": "^2.0.0"
+    "@clc_inc/prettier-config-clc": "^2.0.0",
+    "@trivago/prettier-plugin-sort-imports": "^1.4.4"
   }
 ```
 

--- a/index.js
+++ b/index.js
@@ -3,5 +3,19 @@ module.exports = {
   printWidth: 120,
   singleQuote: true,
   tabWidth: 4,
-  trailingComma: "none"
+  trailingComma: "none",
+  importOrder: [
+    // All packages that start with @ followed by packages that start with any letter"
+    "^@?\\w",
+
+    // Parent imports. `..`
+    "^\\.\\.(?!/?$)",
+    "^\\.\\./?$",
+
+    // Other relative imports
+    "^\\./(?=.*/)(?!/?$)",
+    "^\\.(?!/?$)",
+    "^\\./?$",
+  ],
+  importOrderSeparation: true,
 };

--- a/index.js
+++ b/index.js
@@ -7,15 +7,8 @@ module.exports = {
   importOrder: [
     // All packages that start with @ followed by packages that start with any letter"
     "^@?\\w",
-
-    // Parent imports. `..`
-    "^\\.\\.(?!/?$)",
-    "^\\.\\./?$",
-
-    // Other relative imports
-    "^\\./(?=.*/)(?!/?$)",
-    "^\\.(?!/?$)",
-    "^\\./?$",
+    // File Imports
+    "^[./]",
   ],
   importOrderSeparation: true,
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "repository": "https://github.com/CLCInc/prettier-config-clc",
   "peerDependencies": {
-    "prettier": ">= 1"
+    "prettier": ">= 1",
+    "@trivago/prettier-plugin-sort-imports": "^1.4.4"
   }
 }


### PR DESCRIPTION
# Overview
Adds import sort order to our prettier config. https://github.com/trivago/prettier-plugin-sort-imports

The setting is separated based on sorting imports by;
1. Package Imports
2. File Imports

Updating your package to use this branch without `prettier-plugin-sort-imports` doesn't break anything, though you won't have the sort feature. I included `prettier-plugin-sort-imports` in peerDependencies to inform the user that this package is needed. 

# Examples
`_app.js` 
![Screen Shot 2021-03-03 at 3 13 53 PM](https://user-images.githubusercontent.com/31245853/109885264-14daec00-7c33-11eb-8eb3-3e766508a55f.png)


`a page`
![Screen Shot 2021-03-03 at 3 15 00 PM](https://user-images.githubusercontent.com/31245853/109885412-510e4c80-7c33-11eb-84be-ad2b5ebf2c85.png)


Only es6 modules are ordered;
![Screen Shot 2021-03-03 at 3 16 05 PM](https://user-images.githubusercontent.com/31245853/109885461-61262c00-7c33-11eb-954e-be82f926b2a6.png)
