### PR TITLE
[DEV-1569] Update dep dependencies for babel parser errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ To add this file to your own project, add the following to your project's `packa
 ```js
   "prettier": "@clc_inc/prettier-config-clc"
   "devDependencies": {
-    "prettier": "^1.19.1",
-    "@clc_inc/prettier-config-clc": "^2.0.0",
-    "@trivago/prettier-plugin-sort-imports": "^1.4.4"
+    "prettier": "^2.2.1",
+    "@clc_inc/prettier-config-clc": "^2.1.1",
+    "@trivago/prettier-plugin-sort-imports": "^2.0.1"
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To add this file to your own project, add the following to your project's `packa
   "devDependencies": {
     "prettier": "^2.2.1",
     "@clc_inc/prettier-config-clc": "^2.1.1",
-    "@trivago/prettier-plugin-sort-imports": "^2.0.1"
+    "@trivago/prettier-plugin-sort-imports": "^1.4.4"
   }
 ```
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "repository": "https://github.com/CLCInc/prettier-config-clc",
   "peerDependencies": {
-    "prettier": ">= 1",
-    "@trivago/prettier-plugin-sort-imports": "^1.4.4"
+    "prettier": "^2.2.1",
+    "@trivago/prettier-plugin-sort-imports": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "repository": "https://github.com/CLCInc/prettier-config-clc",
   "peerDependencies": {
     "prettier": "^2.2.1",
-    "@trivago/prettier-plugin-sort-imports": "^2.0.1"
+    "@trivago/prettier-plugin-sort-imports": "^1.4.4"
   }
 }


### PR DESCRIPTION
# Overview
I got some errors when I opted to use `@trivago/prettier-plugin-sort-imports` from our updated prettier config v2.1.0. 
These did not exist last week and looks like it was caused by some [updates with babel](https://github.com/babel/babel/issues/12468).
```
SyntaxError: This experimental syntax requires enabling one of the following parser plugin(s): 'jsx, flow, typescript' 
```

`@trivago/prettier-plugin-sort-imports` listed updates in the last 5 days, but it looks like these were what was causing the issues. 
https://github.com/trivago/prettier-plugin-sort-imports/releases/tag/v2.0.0

## What changed
This PR just updates listed peerDependencies `prettier` & `@trivago/prettier-plugin-sort-imports` to the working versions. 
Upgrading Prettier
Downgrading `@trivago/prettier-plugin-sort-imports`