### PR TITLE
feat: DEV-3227 printWidth change for prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   arrowParens: "always",
-  printWidth: 120,
+  printWidth: 80,
   singleQuote: true,
   tabWidth: 4,
   trailingComma: "none",


### PR DESCRIPTION
I changed this from 120 to 80 to allow for more readability when splitting screens in vscode.

will prevent this from happeni
<img width="861" alt="Screenshot 2024-05-08 at 12 42 25 PM" src="https://github.com/CLCInc/prettier-config-clc/assets/8356638/d94eea4b-199a-479c-aa65-98977dd96b35">
ng on regular screens

and look m
<img width="559" alt="Screenshot 2024-05-08 at 12 39 05 PM" src="https://github.com/CLCInc/prettier-config-clc/assets/8356638/a6ba525f-0fc8-4535-bb94-e1745ab35521">
ore like this
